### PR TITLE
Sign Out bug fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.14.2-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -247,6 +249,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,8 +12,8 @@
     <p class="notice"><%= notice %></p>
     <p class="alert"><%= alert %></p>
   </head>
-  <%= button_to "sign up", new_user_registration_path %>
-  <%= button_to "sign in", user_session_path %>
+  <%= link_to "sign in", user_session_path %>
+  <%= link_to "sign up", new_user_registration_path %>
   <%= button_to "sign out", destroy_user_session_path, method: :delete %>
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
-  get 'play_dates/create'
-  get 'play_dates/index'
-  # get 'pets/index'
-  # get 'pets/new'
+  # get 'play_dates/create'
+  # get 'play_dates/index'
+  get 'pets/index'
+  get 'pets/new'
   # get 'pets/create'
   # get 'pets/show'
   devise_for :users


### PR DESCRIPTION
Devise has issues with Ruby version 7 cannot use `button_to` need to use  `link_to` instead